### PR TITLE
consistent error prompt on non-production environment

### DIFF
--- a/lib/iso-execute-server.js
+++ b/lib/iso-execute-server.js
@@ -27,11 +27,17 @@ var middleware = function (req, res) {
         res.send({rpc: R});
     })['catch'](function (E) {
         console.warn(E.stack);
-        res.status(500).send(('production' !== process.env.NODE_ENV) ? (E.stack || E) : {
-            error: 'Internal Server Error',
-            service: req.params.name,
-            params: req.body
-        });
+        res.status(500).send(('production' !== process.env.NODE_ENV) ?
+            {
+                error: (E.stack || E),
+                service: req.params.name,
+                params: req.body
+            } : {
+                error: 'Internal Server Error',
+                service: req.params.name,
+                params: req.body
+            }
+        );
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "request": "2.55.0"
   },
   "devDependencies": {
-    "babel-eslint": "3.0.1",
+    "babel-eslint": "4.1.3",
     "eslint": "0.20.0",
     "nock": "1.6.1",
     "browser-request": "0.3.3",

--- a/test/iso-execute-server.js
+++ b/test/iso-execute-server.js
@@ -152,10 +152,12 @@ describe('iso-execute-server', function () {
             var res = {
                 status: function (code) {
                     assert.equal(code, 500);
-                    done();
                     return res;
                 },
-                send: function () {}
+                send: function (data) {
+                    assert.equal(data.error, 'ignore this: console.warn(E.stack)');
+                    done();
+                }
             };
 
             isocall.addConfigs({
@@ -166,5 +168,29 @@ describe('iso-execute-server', function () {
 
             getMiddleware()(req, res);
         });
+        it('will res.status(500) when Promise.reject()', function (done) {
+            var req = {
+                params: {name: 'test'}
+            };
+            var res = {
+                status: function (code) {
+                    assert.equal(code, 500);
+                    return res;
+                },
+                send: function (data) {
+                    assert.equal(data.error, 'ignore this: console.warn(E.stack)');
+                    done();
+                }
+            };
+
+            isocall.addConfigs({
+                test: function () {
+                    return Promise.reject({message: 'Error!', stack: 'ignore this: console.warn(E.stack)'});
+                }
+            });
+
+            getMiddleware()(req, res);
+        });
+
     });
 });


### PR DESCRIPTION
Try to return consistent payload for triggering promise-reject on iso-call client side even though on non-production mode.
